### PR TITLE
Use fs instead fs-extra

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const fse = require("fs-extra");
+const fs = require("fs");
 const JSZip = require("jszip");
 const path = require("path");
 
@@ -35,7 +35,7 @@ class ServerlessPluginPackagePath {
         const artifactFilePath = this._artifactFilePath(layerName);
         const packagesPath = this.serverless.service.custom.packagePath.path;
 
-        const artifactBuffer = await fse.readFileAsync(artifactFilePath);
+        const artifactBuffer = await fs.readFileAsync(artifactFilePath);
 
         const tmpPackage = new JSZip();
         const serviceFolder = tmpPackage.folder(
@@ -59,8 +59,8 @@ class ServerlessPluginPackagePath {
         const artifactFilePath = this._artifactFilePath(layerName);
         const packagesPath = this.serverless.service.custom.packagePath.path;
 
-        const artifactBuffer = await fse.readFileAsync(artifactFilePath);
-        const tmpBuffer = await fse.readFileAsync(this._tmpFilePath());
+        const artifactBuffer = await fs.readFileAsync(artifactFilePath);
+        const tmpBuffer = await fs.readFileAsync(this._tmpFilePath());
 
         const artifact = new JSZip();
         const packagesFolder = artifact.folder(packagesPath);
@@ -98,7 +98,7 @@ class ServerlessPluginPackagePath {
             level: 9
           }
         })
-        .pipe(fse.createWriteStream(filePath))
+        .pipe(fs.createWriteStream(filePath))
         .on("finish", resolve)
     );
   }


### PR DESCRIPTION
Closes Fondeadora/serverless-plugin-package-path#2

### Description
Use inbuilt node `fs` instead `fs-extra` package

### What is the current behavior?
Script use `fs-extra`

### What is the new behavior?

Script use inbuilt node `fs`

### How was it tested?
- [x] fondeadora-common-layer
- [x] fondeadora-finance-layer

**Contexto adicional**
<img width="1185" alt="Captura de Pantalla 2020-09-02 a la(s) 11 01 49" src="https://user-images.githubusercontent.com/11889831/92007674-dc9e3380-ed0b-11ea-9a11-37a878ccbd65.png">
